### PR TITLE
Fix file extensions required by file_picker

### DIFF
--- a/lib/src/io/file_selector.mobile.dart
+++ b/lib/src/io/file_selector.mobile.dart
@@ -37,7 +37,7 @@ class FileSelectorMobile extends FileSelectorInterface {
   }) async {
     final file = await FilePicker.getFile(
       type: _toFilePickerFileType(type),
-      fileExtension: type.fileExtensions,
+      allowedExtensions: type.fileExtensions.split('|'),
     );
 
     if (file == null) return null;
@@ -63,7 +63,7 @@ class FileSelectorMobile extends FileSelectorInterface {
 
     final files = await FilePicker.getMultiFile(
       type: _toFilePickerFileType(type),
-      fileExtension: type.fileExtensions,
+      allowedExtensions: type.fileExtensions.split('|'),
     );
 
     if (files == null) return null;


### PR DESCRIPTION
## Description

Arguments passed to FilePicker.getFile and .getFileMany were wrong

